### PR TITLE
Update reusable workflow references to gha-for-devops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.workflow == 'lint-and-scan')
     permissions:
       contents: read
-    uses: dceoy/gh-actions-for-devops/.github/workflows/aws-cloudformation-lint.yml@main  # zizmor: ignore[unpinned-uses]
+    uses: dceoy/gha-for-devops/.github/workflows/aws-cloudformation-lint.yml@main  # zizmor: ignore[unpinned-uses]
     with:
       search-path: .
       python-version: '3.13'
@@ -41,7 +41,7 @@ jobs:
       contents: write
       actions: read
       security-events: write
-    uses: dceoy/gh-actions-for-devops/.github/workflows/terraform-lint-and-scan.yml@main  # zizmor: ignore[unpinned-uses]
+    uses: dceoy/gha-for-devops/.github/workflows/terraform-lint-and-scan.yml@main  # zizmor: ignore[unpinned-uses]
     with:
       search-path: .
       terraform-version: latest
@@ -56,7 +56,7 @@ jobs:
       pull-requests: write
       actions: read
       security-events: write
-    uses: dceoy/gh-actions-for-devops/.github/workflows/terraform-lock-files-upgrade-and-pr-merge.yml@main  # zizmor: ignore[unpinned-uses]
+    uses: dceoy/gha-for-devops/.github/workflows/terraform-lock-files-upgrade-and-pr-merge.yml@main  # zizmor: ignore[unpinned-uses]
     with:
       terraform-working-directories: envs/plt
       terraform-version: latest
@@ -79,7 +79,7 @@ jobs:
       actions: read
       checks: read
       statuses: read
-    uses: dceoy/gh-actions-for-devops/.github/workflows/dependabot-auto-merge.yml@main  # zizmor: ignore[unpinned-uses]
+    uses: dceoy/gha-for-devops/.github/workflows/dependabot-auto-merge.yml@main  # zizmor: ignore[unpinned-uses]
     with:
       unconditional: true
     secrets:


### PR DESCRIPTION
## Summary
- replace reusable workflow references from `dceoy/gh-actions-for-devops` to `dceoy/gha-for-devops`

## Why
The reusable workflow repository has been renamed to `gha-for-devops`.

## Impact
No workflow behavior is changed; only the repository path used by reusable workflow calls is updated.

## Validation
- confirmed all changed references are under `.github/workflows`
- confirmed the changed files contain no remaining `dceoy/gh-actions-for-devops` reference